### PR TITLE
Feature: Close telescope window after performing open_in_browser action

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ require("telescope").setup({
         width = 0.5,
         height = 0.5,
       },
+      actions_opts = {
+        open_in_browser = {
+          -- Close the telescope window when opening in browser
+          auto_close = false,
+        },
+      }
       -- Other telescope configuration options
     },
   },

--- a/lua/telescope/_extensions/lazy/actions.lua
+++ b/lua/telescope/_extensions/lazy/actions.lua
@@ -72,7 +72,7 @@ function M.open_in_terminal()
   terminal:open(selected_entry.path, builtin.resume)
 end
 
-function M.open_in_browser()
+function M.open_in_browser(prompt_bufnr)
   local open_cmd
   if vim.fn.executable("xdg-open") == 1 then
     open_cmd = "xdg-open"
@@ -103,6 +103,10 @@ function M.open_in_browser()
         vim.log.levels.ERROR,
         { title = telescope_lazy_config.extension_name }
       )
+    end
+
+    if telescope_lazy_config.opts.actions_opts.open_in_browser.auto_close then
+      actions.close(prompt_bufnr)
     end
   end
 end

--- a/lua/telescope/_extensions/lazy/config.lua
+++ b/lua/telescope/_extensions/lazy/config.lua
@@ -26,6 +26,11 @@ M.defaults = {
     width = 0.5,
     height = 0.5,
   },
+  actions_opts = {
+    open_in_browser = {
+      auto_close = false,
+    },
+  },
 }
 
 M.opts = {}


### PR DESCRIPTION
Added an opt-in config option to keep original behavior as default