### PR TITLE
feat(actions): Add open_in_mini_files action

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ require("telescope").load_extension "lazy"
 | -------- | ----------------------------------------------------------------------------- |
 | `<C-o>`  | Open selected plugin repository in browser                                    |
 | `<M-b>`  | Open selected plugin with file-browser                                        |
-| `<M-f>`  | Open selected plugin with mini.files                                         |
+| `<M-f>`  | Open selected plugin with mini.files                                          |
 | `<C-f>`  | Open selected plugin with find files                                          |
 | `<C-g>`  | Open selected plugin with live grep (will use `egrepify` if installed)        |
 | `<C-t>`  | Open selected plugin in a terminal                                            |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Optional:
 
 - [telescope-file-browser.nvim](https://github.com/nvim-telescope/telescope-file-browser.nvim)
 - [telescope-egrepify.nvim](https://github.com/fdschmidt93/telescope-egrepify.nvim)
+- [mini.files](https://github.com/echasnovski/mini.files)
 
 ## Installation
 
@@ -44,6 +45,7 @@ require("telescope").setup({
       mappings = {
         open_in_browser = "<C-o>",
         open_in_file_browser = "<M-b>",
+        open_in_mini_files = "<M-f>",
         open_in_find_files = "<C-f>",
         open_in_live_grep = "<C-g>",
         open_in_terminal = "<C-t>",
@@ -92,6 +94,7 @@ require("telescope").load_extension "lazy"
 | -------- | ----------------------------------------------------------------------------- |
 | `<C-o>`  | Open selected plugin repository in browser                                    |
 | `<M-b>`  | Open selected plugin with file-browser                                        |
+| `<M-f>`  | Open selected plugin with mini.files                                         |
 | `<C-f>`  | Open selected plugin with find files                                          |
 | `<C-g>`  | Open selected plugin with live grep (will use `egrepify` if installed)        |
 | `<C-t>`  | Open selected plugin in a terminal                                            |

--- a/lua/telescope/_extensions/lazy/actions.lua
+++ b/lua/telescope/_extensions/lazy/actions.lua
@@ -180,6 +180,25 @@ function M.open_in_file_browser()
   })
 end
 
+function M.open_in_mini_files()
+  local ok, mini = pcall(require, "mini.files")
+  if not ok then
+    vim.notify(
+      "This action requires 'mini.files'. (https://github.com/echasnovski/mini.files)",
+      vim.log.levels.ERROR,
+      { title = telescope_lazy_config.extension_name }
+    )
+    return
+  end
+
+  local selected_entry = get_selected_entry()
+  if not selected_entry then
+    return
+  end
+
+  mini.open(selected_entry.path)
+end
+
 function M.default_action_replace(prompt_bufnr)
   actions.select_default:replace(function()
     local selected_entry = get_selected_entry()

--- a/lua/telescope/_extensions/lazy/config.lua
+++ b/lua/telescope/_extensions/lazy/config.lua
@@ -9,6 +9,7 @@ M.defaults = {
   mappings = {
     open_in_browser = "<C-o>",
     open_in_file_browser = "<M-b>",
+    open_in_mini_files = "<M-f>",
     open_in_find_files = "<C-f>",
     open_in_live_grep = "<C-g>",
     open_in_terminal = "<C-t>",


### PR DESCRIPTION
Provides an alternative to open_in_filebrowser()

I guess it does not handle setting mini.files as dependency.
I could add a line regarding this in the documentation if you want.


I hope this is ok, as this is my first PR. I just added an alternative function to open files with mini files. 

Thanks for this plugin!

kind regards