### PR TITLE
feat(types): Add type definitions for the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ provides handy functionality about plugins installed via
 
 [Telescope-lazy-demo.webm](https://github.com/tsakirist/telescope-lazy.nvim/assets/20475201/d5f2a772-b45d-422f-b566-1d92359f7dba)
 
-## Requirements
+## Dependencies
 
 Required:
 
@@ -30,41 +30,39 @@ Optional:
 
 ## Configuration
 
-The extension comes with the following defaults:
+Example setup:
 
 ```lua
 require("telescope").setup({
   extensions = {
+    -- Type information can be loaded via 'https://github.com/folke/lazydev.nvim'
+    -- by adding the below two annotations:
+    ---@module "telescope._extensions.lazy"
+    ---@type TelescopeLazy.Config
     lazy = {
       -- Optional theme (the extension doesn't set a default theme)
       theme = "ivy",
-      -- Whether or not to show the icon in the first column
+      -- The below configuration options are the defaults
       show_icon = true,
-      -- Mappings for the actions
       mappings = {
         open_in_browser = "<C-o>",
         open_in_file_browser = "<M-b>",
         open_in_find_files = "<C-f>",
         open_in_live_grep = "<C-g>",
         open_in_terminal = "<C-t>",
-        open_plugins_picker = "<C-b>", -- Works only after having called first another action
+        open_plugins_picker = "<C-b>",
         open_lazy_root_find_files = "<C-r>f",
         open_lazy_root_live_grep = "<C-r>g",
         change_cwd_to_plugin = "<C-c>d",
       },
-      -- Extra configuration options for the actions
       actions_opts = {
         open_in_browser = {
-          -- Close the telescope window after the action is executed
           auto_close = false,
         },
         change_cwd_to_plugin = {
-          -- Close the telescope window after the action is executed
           auto_close = false,
         },
       },
-      -- Configuration that will be passed to the window that hosts the terminal
-      -- For more configuration options check 'nvim_open_win()'
       terminal_opts = {
         relative = "editor",
         style = "minimal",
@@ -79,14 +77,95 @@ require("telescope").setup({
   },
 })
 
-require("telescope").load_extension "lazy"
+require("telescope").load_extension("lazy")
 ```
 
-## Available Commands
+<details>
+    <summary>Default settings</summary>
+
+```lua
+---@type TelescopeLazy.Config
+local defaults = {
+  -- Whether or not to show the icon in the first column
+  show_icon = true,
+  -- Mappings for the actions
+  mappings = {
+    open_in_browser = "<C-o>",
+    open_in_file_browser = "<M-b>",
+    open_in_find_files = "<C-f>",
+    open_in_live_grep = "<C-g>",
+    open_in_terminal = "<C-t>",
+    open_plugins_picker = "<C-b>", -- Works only after having called first another action
+    open_lazy_root_find_files = "<C-r>f",
+    open_lazy_root_live_grep = "<C-r>g",
+    change_cwd_to_plugin = "<C-c>d",
+  },
+  -- Extra configuration options for the actions
+  actions_opts = {
+    open_in_browser = {
+      -- Close the telescope window after the action is executed
+      auto_close = false,
+    },
+    change_cwd_to_plugin = {
+      -- Close the telescope window after the action is executed
+      auto_close = false,
+    },
+  },
+  -- Configuration that will be passed to the window that hosts the terminal
+  -- For more configuration options check 'nvim_open_win()'
+  terminal_opts = {
+    relative = "editor",
+    style = "minimal",
+    border = "rounded",
+    title = "Telescope lazy",
+    title_pos = "center",
+    width = 0.5,
+    height = 0.5,
+  },
+}
+```
+
+</details>
+
+<details>
+    <summary>Types</summary>
+
+```lua
+---@class TelescopeLazy.Config
+---@field show_icon? boolean Whether or not to show the icon in the first column of the picker.
+---@field mappings? TelescopeLazy.Mappings Mappings for the picker actions.
+---@field actions_opts? TelescopeLazy.ActionsOpts Configuration options for the picker actions.
+---@field terminal_opts? vim.api.keyset.win_config Configuration for the terminal window action.
+---@field theme? TelescopeLazy.Theme The Telescope theme to use for the picker.
+
+---@alias TelescopeLazy.Theme "dropdown" | "cursor" |"ivy"
+
+---@class TelescopeLazy.Mappings
+---@field open_in_browser? string
+---@field open_in_file_browser? string
+---@field open_in_find_files? string
+---@field open_in_live_grep? string
+---@field open_in_terminal? string
+---@field open_plugins_picker? string
+---@field open_lazy_root_find_files? string
+---@field open_lazy_root_live_grep? string
+---@field change_cwd_to_plugin? string
+
+---@class TelescopeLazy.ActionOpts
+---@field auto_close? boolean Automatically close the telescope window after the action is executed.
+
+---@class TelescopeLazy.ActionsOpts
+---@field open_in_browser TelescopeLazy.ActionOpts
+---@field change_cwd_to_plugin TelescopeLazy.ActionOpts
+```
+
+</details>
+
+## Commands
 
 `:Telescope lazy`
 
-## Available mappings
+## Mappings
 
 | Mappings | Action                                                                        |
 | -------- | ----------------------------------------------------------------------------- |

--- a/lua/telescope/_extensions/lazy/config.lua
+++ b/lua/telescope/_extensions/lazy/config.lua
@@ -4,6 +4,7 @@ local M = {}
 
 M.extension_name = "Telescope lazy"
 
+---@type TelescopeLazy.Config
 M.defaults = {
   show_icon = true,
   mappings = {
@@ -36,22 +37,26 @@ M.defaults = {
   },
 }
 
+---@type TelescopeLazy.Config
 M.opts = {}
 
-function M.setup(user_opts)
-  user_opts = user_opts or {}
-  if user_opts.theme and string.len(user_opts.theme) > 0 then
-    if not themes["get_" .. user_opts.theme] then
+---@param opts? TelescopeLazy.Config
+function M.setup(opts)
+  opts = opts or {}
+
+  if opts.theme and string.len(opts.theme) > 0 then
+    if not themes["get_" .. opts.theme] then
       vim.notify(
-        string.format("Could not apply provided telescope theme: '%s'", user_opts.theme),
+        string.format("Could not apply provided telescope theme: '%s'", opts.theme),
         vim.log.levels.WARN,
         { title = M.extension_name }
       )
     else
-      user_opts = themes["get_" .. user_opts.theme](user_opts)
+      opts = themes["get_" .. opts.theme](opts)
     end
   end
-  M.opts = vim.tbl_deep_extend("force", M.defaults, user_opts)
+
+  M.opts = vim.tbl_deep_extend("force", M.defaults, opts)
 end
 
 return M

--- a/lua/telescope/_extensions/lazy/plugins.lua
+++ b/lua/telescope/_extensions/lazy/plugins.lua
@@ -35,10 +35,10 @@ local function find_readme(path)
 end
 
 --- Creates an internal representation of a LazyPlugin.
----@param lazy_plugin any: An instance of a LazyPlugin.
----@return Plugin: An internal representation of the LazyPlugin as a Plugin.
+---@param lazy_plugin LazyPlugin: An instance of a LazyPlugin.
+---@return TelescopeLazy.Plugin: An internal representation of the LazyPlugin as a Plugin.
 local function create_plugin_from_lazy(lazy_plugin)
-  ---@type Plugin
+  ---@type TelescopeLazy.Plugin
   ---@diagnostic disable-next-line: missing-fields
   local plugin = {}
 
@@ -57,9 +57,9 @@ local function create_plugin_from_lazy(lazy_plugin)
 end
 
 --- Returns a table describing the plugins installed via the lazy package manager.
----@return table<Plugin>: A table containing information about installed plugins.
+---@return table<TelescopeLazy.Plugin>: A table containing information about installed plugins.
 function M.plugins()
-  ---@type table<Plugin>
+  ---@type table<TelescopeLazy.Plugin>
   local plugins = {}
 
   for _, lazy_plugin in pairs(lazy_config.plugins) do

--- a/lua/telescope/_extensions/lazy/types.lua
+++ b/lua/telescope/_extensions/lazy/types.lua
@@ -1,4 +1,31 @@
----@class Plugin
+---@class TelescopeLazy.Config
+---@field show_icon? boolean Whether or not to show the icon in the first column of the picker.
+---@field mappings? TelescopeLazy.Mappings Mappings for the picker actions.
+---@field actions_opts? TelescopeLazy.ActionsOpts Configuration options for the picker actions.
+---@field terminal_opts? vim.api.keyset.win_config Configuration for the terminal window action.
+---@field theme? TelescopeLazy.Theme The Telescope theme to use for the picker.
+
+---@alias TelescopeLazy.Theme "dropdown" | "cursor" |"ivy"
+
+---@class TelescopeLazy.Mappings
+---@field open_in_browser? string
+---@field open_in_file_browser? string
+---@field open_in_find_files? string
+---@field open_in_live_grep? string
+---@field open_in_terminal? string
+---@field open_plugins_picker? string
+---@field open_lazy_root_find_files? string
+---@field open_lazy_root_live_grep? string
+---@field change_cwd_to_plugin? string
+
+---@class TelescopeLazy.ActionOpts
+---@field auto_close? boolean Automatically close the telescope window after the action is executed.
+
+---@class TelescopeLazy.ActionsOpts
+---@field open_in_browser TelescopeLazy.ActionOpts
+---@field change_cwd_to_plugin TelescopeLazy.ActionOpts
+
+---@class TelescopeLazy.Plugin
 ---@field path string
 ---@field name string
 ---@field readme string|nil


### PR DESCRIPTION
Add type definitions so the user can load the configuration typings by properly setting up the language server. This can easily be achieved by using 'https://github.com/folke/lazydev.nvim'.

Update README.md with types and show how to properly load typings in setup.